### PR TITLE
Updated geth flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ start: build
 	--memory=$(MEMORY) --memory-swap=$(SWAP_MEMORY) --memory-swappiness=80 --oom-kill-disable \
 	--cpus=$(CPUS) \
 	-v $$HOME/ropsten-miner/data:/root/.ethereum ethereum/client-go \
-	--syncmode "fast" --networkid 3 --testnet --rpc --rpcaddr "0.0.0.0" --mine --etherbase $(ETHER_ADDR) \
+	--syncmode "fast" --networkid 3 --ropsten --http --http.addr "0.0.0.0" --mine --miner.etherbase $(ETHER_ADDR) \
 	--rpcapi admin,eth,debug,miner,net,txpool,personal,web3 \
 	--metrics
 

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ start: build
 	--cpus=$(CPUS) \
 	-v $$HOME/ropsten-miner/data:/root/.ethereum ethereum/client-go \
 	--syncmode "fast" --networkid 3 --testnet --rpc --rpcaddr "0.0.0.0" --mine --etherbase $(ETHER_ADDR) \
-	--rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3 \
+	--rpcapi admin,eth,debug,miner,net,txpool,personal,web3 \
 	--metrics
 
 shell:


### PR DESCRIPTION
Thanks for this example. 

I tried running it and found that the flags changed for `--testnet, --rpc,` etc:

```
Incorrect Usage. flag provided but not defined: -testnet
Incorrect Usage. flag provided but not defined: -rpc
```

Also the db and shh modules are unavailable:

```
ERROR[10-11|13:41:27.702] Unavailable modules in HTTP API list     unavailable="[db shh]" available="[admin debug web3 eth txpool personal ethash miner net]"
```

I've updated to the correct flags in the Makefile.